### PR TITLE
feat: workaround for left click context menu on KDE

### DIFF
--- a/src/sys/linux/dbus/mod.rs
+++ b/src/sys/linux/dbus/mod.rs
@@ -42,6 +42,7 @@ pub fn register_notifier_item_watcher_blocking(
     icon_height: u32,
     tooltip: String,
     title: String,
+    item_is_menu: bool,
 ) -> (
     StatusNotifierWatcherProxy<'static>,
     Arc<Mutex<KdeIcon>>,
@@ -69,6 +70,7 @@ pub fn register_notifier_item_watcher_blocking(
             icon_data: icon_data.clone(),
             tooltip: tooltip_data.clone(),
             title: title_data.clone(),
+            item_is_menu,
         };
         let _ = connection
             .object_server()

--- a/src/sys/linux/dbus/status_notifier_item.rs
+++ b/src/sys/linux/dbus/status_notifier_item.rs
@@ -25,6 +25,7 @@ pub struct StatusNotifierItemImpl {
     pub icon_data: Arc<Mutex<KdeIcon>>,
     pub tooltip: Arc<Mutex<String>>,
     pub title: Arc<Mutex<String>>,
+    pub item_is_menu: bool,
 }
 
 #[interface(name = "org.kde.StatusNotifierItem")]
@@ -159,7 +160,7 @@ impl StatusNotifierItemImpl {
     /// ItemIsMenu property
     #[zbus(property)]
     pub fn item_is_menu(&self) -> zbus::fdo::Result<bool> {
-        Ok(false)
+        Ok(self.item_is_menu)
     }
 
     /// Menu property

--- a/src/sys/linux/kdetrayicon.rs
+++ b/src/sys/linux/kdetrayicon.rs
@@ -49,6 +49,7 @@ where
         on_click: Option<T>,
         _on_double_click: Option<T>,
         _on_right_click: Option<T>,
+        item_is_menu: bool,
     ) -> Result<KdeTrayIconImpl<T>, Error> {
         let connection = get_dbus_connection();
         let (sender, receiver) = std::sync::mpsc::channel();
@@ -70,6 +71,7 @@ where
                 icon_height,
                 tooltip,
                 title,
+                item_is_menu,
             );
 
         // Store the event_sender if menu exists

--- a/src/sys/linux/mod.rs
+++ b/src/sys/linux/mod.rs
@@ -56,6 +56,7 @@ where
     let on_right_click = builder.on_right_click.clone();
     let sender = builder.sender.clone().ok_or(Error::SenderMissing)?;
     let on_double_click = builder.on_double_click.clone();
+    let item_is_menu = builder.item_is_menu.clone();
     // let notify_icon = WinNotifyIcon::new(hicon, tooltip);
 
     // Try to get a popup menu
@@ -93,6 +94,7 @@ where
         on_click,
         on_double_click,
         on_right_click,
+        item_is_menu,
     )?)
 }
 

--- a/src/trayicon.rs
+++ b/src/trayicon.rs
@@ -103,7 +103,8 @@ where
 
     /// Show the menu (Windows only)
     ///
-    /// On KDE and MacOS right click by default opens the menu, there is no programmatic way to open it.
+    /// On KDE and MacOS right click by default opens the menu, there is no programmatic way to open it.  
+    /// On KDE, see [item_is_menu](crate::trayiconbuilder::TrayIconBuilder::item_is_menu) as a workaround
     pub fn show_menu(&mut self) -> Result<(), Error> {
         self.sys.show_menu()
     }

--- a/src/trayiconbuilder.rs
+++ b/src/trayiconbuilder.rs
@@ -40,6 +40,7 @@ where
     pub(crate) on_click: Option<T>,
     pub(crate) on_double_click: Option<T>,
     pub(crate) on_right_click: Option<T>,
+    pub(crate) item_is_menu: bool,
     pub(crate) sender: Option<TrayIconSender<T>>,
 }
 
@@ -57,6 +58,7 @@ where
             on_click: None,
             on_double_click: None,
             on_right_click: None,
+            item_is_menu: false,
             sender: None,
         }
     }
@@ -133,5 +135,13 @@ where
 
     pub fn build(self) -> Result<TrayIcon<T>, Error> {
         Ok(TrayIcon::new(crate::build_trayicon(&self)?, self))
+    }
+
+    /// Indicates that this item only supports the context menu. 
+    ///
+    /// Set this to true if you want to be able to open the context menu with left click. KDE only
+    pub fn item_is_menu(mut self, value: bool) -> Self {
+        self.item_is_menu = value;
+        self
     }
 }


### PR DESCRIPTION
This PR exposes to the user kstatusnotifieritem's `item_is_menu` property and adds a method to configure it. This way, on KDE, setting it to true makes it so the context menu can be opened with left click

There are two points I'd like to discuss:
- To keep the same default with prior trayicon versions, `item_is_menu` is set to false by default. It might be a a sensible default to set it to true
- I loosely followed the naming scheme of the project, and the setter for this property is just called `item_is_menu`. Might be worth it to follow kde's api naming scheme and call it [`set_is_menu`](https://api.kde.org/kstatusnotifieritem.html#setIsMenu)