### PR TITLE
Avoid infinite recursion in Display impl for Error

### DIFF
--- a/src/trayiconbuilder.rs
+++ b/src/trayiconbuilder.rs
@@ -19,7 +19,7 @@ impl From<&Error> for Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
`cargo clippy` gives this error:
```rust
error: using `self` as `Display` in `impl Display` will cause infinite recursion
  --> src/trayiconbuilder.rs:22:9
   |
22 |         write!(f, "{}", self)
   |         ^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#recursive_format_impl
   = note: `#[deny(clippy::recursive_format_impl)]` on by default
   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Using the `Debug` implementation works for now. Alternatively, I'd suggest using either `thiserror` or `derive_more`