### PR TITLE
Use Cow<&'static, [u8]> for icon buffers

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 #[derive(Clone)]
 pub struct Icon {
-    buffer: Option<&'static [u8]>,
+    buffer: Option<std::borrow::Cow<'static, [u8]>>,
     pub(crate) sys: crate::IconSys,
 }
 
@@ -15,12 +15,12 @@ impl Debug for Icon {
 
 impl Icon {
     pub fn from_buffer(
-        buffer: &'static [u8],
+        buffer: std::borrow::Cow<'static, [u8]>,
         width: Option<u32>,
         height: Option<u32>,
     ) -> Result<Icon, Error> {
         Ok(Icon {
-            buffer: Some(buffer),
+            buffer: Some(buffer.clone()),
             sys: crate::IconSys::from_buffer(buffer, width, height)?,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ where
 /// IconSys must implement this
 pub(crate) trait IconBase {
     fn from_buffer(
-        buffer: &'static [u8],
+        buffer: std::borrow::Cow<'static, [u8]>,
         width: Option<u32>,
         height: Option<u32>,
     ) -> Result<IconSys, Error>;

--- a/src/sys/linux/kdeicon.rs
+++ b/src/sys/linux/kdeicon.rs
@@ -11,7 +11,7 @@ pub struct KdeIcon {
 
 impl IconBase for KdeIcon {
     fn from_buffer(
-        buffer: &'static [u8],
+        buffer: std::borrow::Cow<'static, [u8]>,
         _width: Option<u32>,
         _height: Option<u32>,
     ) -> Result<KdeIcon, Error> {

--- a/src/sys/macos/icon.rs
+++ b/src/sys/macos/icon.rs
@@ -11,7 +11,7 @@ pub struct MacIcon {
 
 impl IconBase for MacIcon {
     fn from_buffer(
-        buffer: &'static [u8],
+        buffer: std::borrow::Cow<'static, [u8]>,
         width: Option<u32>,
         height: Option<u32>,
     ) -> Result<MacIcon, Error> {

--- a/src/sys/windows/winhicon.rs
+++ b/src/sys/windows/winhicon.rs
@@ -11,7 +11,7 @@ pub struct WinHIcon {
 
 impl IconBase for WinHIcon {
     fn from_buffer(
-        buffer: &'static [u8],
+        buffer: std::borrow::Cow<'static, [u8]>,
         width: Option<u32>,
         height: Option<u32>,
     ) -> Result<WinHIcon, Error> {

--- a/src/trayiconbuilder.rs
+++ b/src/trayiconbuilder.rs
@@ -118,7 +118,7 @@ where
         self
     }
 
-    pub fn icon_from_buffer(mut self, buffer: &'static [u8]) -> Self {
+    pub fn icon_from_buffer(mut self, buffer: std::borrow::Cow<'static, [u8]>) -> Self {
         self.icon = Icon::from_buffer(buffer, None, None);
         self
     }


### PR DESCRIPTION
Requiring static slices is a hard requirement to meet. A simple drop-in solution is to use CoW slices instead. In the future maybe `Icon` doesn't even need to store the originating buffer and this could just be an `&'a [u8]`.